### PR TITLE
Update dependency versions. Bump version 1.2.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,9 +1,9 @@
-(defproject brave-ring "1.1.0"
+(defproject brave-ring "1.2.0"
   :description "Brave (zipkin) middleware for ring"
   :url "http://github.com/dbrenden/brave-ring"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [com.github.kristofa/brave-core "3.4.0"]
-                 [prismatic/schema "0.4.4"]
+                 [io.zipkin.brave/brave-core "3.18.0"]
+                 [prismatic/schema "1.1.6"]
                  [org.clojure/tools.logging "0.3.1"]])


### PR DESCRIPTION
 - Prismatic schema
 - Brave - latest v3 API (not v4). Also uses new Maven group name.